### PR TITLE
Fix electric vehicle tax rounding to match belastingdienst.nl

### DIFF
--- a/src/app/car-tax-form/car-tax-form.component.spec.ts
+++ b/src/app/car-tax-form/car-tax-form.component.spec.ts
@@ -67,10 +67,10 @@ describe('calculatePrice (2026 MRB rates)', () => {
     expect(price('NH', 'LPG', 1551)).toBe(579);
   });
 
-  it('NH Elektrisch 1551 = 70% of Benzine', () => {
+  it('NH Elektrisch 1551 = 70% of Benzine (floored, matching belastingdienst.nl)', () => {
     const benzine = price('NH', 'Benzine', 1551);
     const electric = price('NH', 'Elektrisch', 1551);
-    expect(electric).toBe(Math.round(benzine * 0.70));
+    expect(electric).toBe(Math.floor(benzine * 0.70));
   });
 
   // Legacy Hybride maps to same as Benzine

--- a/src/app/car-tax-form/car-tax-form.component.ts
+++ b/src/app/car-tax-form/car-tax-form.component.ts
@@ -28,7 +28,7 @@ export function calculatePrice(grid: Grid, value: FormValue): number {
   const { col, multiplier } = FUEL_CONFIG[value.fuelType] ?? { col: 1, multiplier: 1 };
 
   if (value.volume < 551) {
-    return Math.round(+grid[value.provinceKey][0].split('#')[col] * multiplier);
+    return Math.floor(+grid[value.provinceKey][0].split('#')[col] * multiplier);
   }
 
   const provinceGrid = grid[value.provinceKey];
@@ -36,7 +36,7 @@ export function calculatePrice(grid: Grid, value: FormValue): number {
   const weight = +provinceGrid[index].split('#')[0];
   const row = value.volume < weight ? index - 1 : index;
 
-  return Math.round(+provinceGrid[row].split('#')[col] * multiplier);
+  return Math.floor(+provinceGrid[row].split('#')[col] * multiplier);
 }
 
 @Component({


### PR DESCRIPTION
## Summary

- `calculatePrice` now uses `Math.floor` instead of `Math.round` when applying the electric vehicle discount multiplier (0.70)
- Confirmed against the official belastingdienst.nl calculator: `391 × 0.70 = 273.7` → floor gives **273**, round gave **274**
- Updated spec assertion to use `Math.floor` to match the official behaviour

## Test plan

- [ ] All 20 unit tests pass (`npm test`)
- [ ] Manual: look up a Polestar 2 (e.g. `P-346-NL`, FL province) — app should show **€273/quarter**, matching belastingdienst.nl

🤖 Generated with [Claude Code](https://claude.com/claude-code)