### PR TITLE
feat(kenteken-scan): allow gallery photo in addition to live camera

### DIFF
--- a/src/app/car-tax-form/car-tax-form.component.html
+++ b/src/app/car-tax-form/car-tax-form.component.html
@@ -17,7 +17,7 @@
   <!-- Plate lookup -->
   <div class="plate-section">
     <!-- Hidden file input for camera scan — id used by label below -->
-    <input id="scanFileInput" type="file" accept="image/*" capture="environment"
+    <input id="scanFileInput" type="file" accept="image/*"
            class="scan-file-input" (change)="onFileSelected($event)" aria-hidden="true">
 
     <div *ngIf="!vehicleInfo" class="plate-search-row">


### PR DESCRIPTION
## Summary

Removes `capture="environment"` from the scan file input so mobile browsers show their native picker sheet instead of opening the camera directly.

- **Before**: tapping scan opened the camera immediately
- **After**: iOS shows "Take Photo / Choose from Library", Android shows a similar picker

Gallery photos are often better quality for OCR (full resolution, no motion blur).

## Test plan

- [ ] Triple-tap NL badge to enable scan
- [ ] Tap scan button on iOS → sheet appears with "Take Photo" and "Choose from Library"
- [ ] Pick an existing plate photo from gallery → OCR recognises the plate

🤖 Generated with [Claude Code](https://claude.com/claude-code)