### PR TITLE
fix(kenteken-scan): downscale large images to fix mobile scan errors

### DIFF
--- a/src/app/car-tax-form/kenteken-scan.service.ts
+++ b/src/app/car-tax-form/kenteken-scan.service.ts
@@ -101,10 +101,15 @@ export class KentekenScanService {
         URL.revokeObjectURL(url);
         LOG(`prepareImage: image loaded ${img.naturalWidth}×${img.naturalHeight}px`);
 
+        // Cap input at 1500px — gallery photos from modern phones can be 12MP+,
+        // which blows the mobile browser memory budget when getImageData is called.
+        const MAX = 1500;
+        const scale = Math.min(1, MAX / Math.max(img.naturalWidth, img.naturalHeight));
         const canvas = document.createElement('canvas');
-        canvas.width = img.naturalWidth;
-        canvas.height = img.naturalHeight;
-        canvas.getContext('2d')!.drawImage(img, 0, 0);
+        canvas.width  = Math.round(img.naturalWidth  * scale);
+        canvas.height = Math.round(img.naturalHeight * scale);
+        canvas.getContext('2d')!.drawImage(img, 0, 0, canvas.width, canvas.height);
+        if (scale < 1) LOG(`prepareImage: downscaled ×${scale.toFixed(2)} → ${canvas.width}×${canvas.height}`);
 
         // 1. Try HSV-based yellow crop (handles pure yellow through amber/gold)
         let plateCanvas = this.cropYellow(canvas);


### PR DESCRIPTION
## Problem

Gallery photos from modern phones (Samsung S23, iPhone etc.) can be 12MP+. Creating a canvas at full resolution and calling `getImageData()` allocates 48MB+ of raw pixel data — mobile browsers hit their memory limit and the canvas fails silently, causing a generic "Kenteken niet herkend" error for every scan attempt.

## Fix

Cap the input canvas at 1500px on the longest side before any processing. Yellow detection and plate localization still work fine at 1500px; the existing `upscale` step ensures the OCR crop reaches ≥800px for Tesseract.

## Test plan

- [ ] Take a photo with Samsung S23 camera → scan succeeds
- [ ] Pick a gallery photo → scan succeeds
- [ ] Desktop behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)