### PR TITLE
fix: stamp build timestamp when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "ng lint",
-    "publish": "ng build --configuration production --base-href='https://maximsemenov.github.io/dutch-car-tax/' && node ./publish.js",
+    "publish": "npm run build -- --configuration production --base-href='https://maximsemenov.github.io/dutch-car-tax/' && node ./publish.js",
     "serve:ssr:cartax": "node dist/server/server.mjs"
   },
   "private": true,


### PR DESCRIPTION
## Problem

The footer showed `dev` instead of the build timestamp because the `publish` script called `ng build` directly, bypassing the `prebuild` npm hook that writes the timestamp to `src/build-time.ts`.

## Fix

Changed `publish` to use `npm run build -- ...` so `prebuild` always fires first, regardless of how the build is triggered.

## Test plan

- [ ] Run `npm run publish` → footer should show a real timestamp like `2026-05-10 09:30`

🤖 Generated with [Claude Code](https://claude.com/claude-code)