### PR TITLE
fix(kenteken-scan): validate all OCR candidates against RDW

### DIFF
--- a/src/app/car-tax-form/car-tax-form.component.ts
+++ b/src/app/car-tax-form/car-tax-form.component.ts
@@ -1,5 +1,5 @@
 import { BUILD_TIME } from '../../build-time';
-import { concat, Observable, BehaviorSubject, combineLatest } from 'rxjs';
+import { concat, Observable, BehaviorSubject, combineLatest, firstValueFrom } from 'rxjs';
 import { map, delay, filter, take, debounceTime, shareReplay } from 'rxjs/operators';
 import { Component, OnInit, ViewChild, Inject, PLATFORM_ID, NgZone, ChangeDetectorRef } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
@@ -269,12 +269,22 @@ export class CarTaxFormComponent implements OnInit {
         return;
       }
 
-      // Fill with the best OCR candidate and let the existing search flow
-      // show vehicle info or "not found" — avoids a redundant extra RDW call
+      // Validate candidates against RDW — OCR can produce multiple valid-looking
+      // plates; the first one isn't always the real plate. Try each in order and
+      // use the first one that exists in the RDW registry.
+      let matchedPlate: string | null = null;
+      for (const candidate of candidates.slice(0, 6)) {
+        const vehicle = await firstValueFrom(this._rdwService.lookupVehicle(candidate));
+        if (vehicle?.massa_ledig_voertuig) {
+          matchedPlate = candidate;
+          break;
+        }
+      }
+
       this._zone.run(() => {
-        this.plateInput = candidates[0];
+        this.plateInput = matchedPlate ?? candidates[0];
         this.scanState = 'idle';
-        this._analytics.event('kenteken_scan_success', { plate: candidates[0] });
+        this._analytics.event('kenteken_scan_success', { plate: this.plateInput });
         this._cdr.detectChanges();
         this.searchVehicle();
       });


### PR DESCRIPTION
## Problem

The first OCR candidate isn't always the real plate. Confusable character substitutions generate multiple valid-looking plate formats — for example, scanning `39-NBT-5` produced 15 candidates with `39-NB-T5` (false) at index 0 and `39-NBT-5` (real) at index 1. The app only searched RDW for `candidates[0]`, so it always showed "not found" for these cases.

## Fix

Try up to 6 candidates in order against the RDW registry. Use the first one that returns a real vehicle. If none match, fall back to `candidates[0]` and let the existing "not found" flow handle it.

This is what the test harness comment already said: *"In the app all candidates are validated against RDW, so order doesn't matter."* — now that's actually true.

## Test plan

- [ ] Scan `39-NBT-5.jpg` → correctly identifies the vehicle (was broken before)
- [ ] Scan a plate where candidates[0] is real → still works (no regression)
- [ ] Scan an unrecognisable image → still shows error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)