### PR TITLE
fix: stamp build timestamp in Netlify deploys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm install && ng build --configuration production"
+  command = "npm install && npm run build -- --configuration production"
   publish = "dist/browser"
 
 [build.environment]


### PR DESCRIPTION
## Problem

Netlify's build command was `ng build` directly, bypassing the `prebuild` npm hook that writes the timestamp to `src/build-time.ts`. The footer always showed `dev`.

## Fix

Changed `netlify.toml` build command to `npm run build -- --configuration production` so `prebuild` always runs first, same as the local `publish` script.

## Test plan

- [ ] After merge, check the footer shows a real timestamp (e.g. `2026-05-10 09:30`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)