### PR TITLE
fix(kenteken-scan): parallel RDW candidate validation

### DIFF
--- a/src/app/car-tax-form/car-tax-form.component.ts
+++ b/src/app/car-tax-form/car-tax-form.component.ts
@@ -269,17 +269,17 @@ export class CarTaxFormComponent implements OnInit {
         return;
       }
 
-      // Validate candidates against RDW — OCR can produce multiple valid-looking
-      // plates; the first one isn't always the real plate. Try each in order and
-      // use the first one that exists in the RDW registry.
-      let matchedPlate: string | null = null;
-      for (const candidate of candidates.slice(0, 6)) {
-        const vehicle = await firstValueFrom(this._rdwService.lookupVehicle(candidate));
-        if (vehicle?.massa_ledig_voertuig) {
-          matchedPlate = candidate;
-          break;
-        }
-      }
+      // Validate candidates against RDW in parallel — OCR produces multiple
+      // valid-looking plates; the first isn't always the real one.
+      const top = candidates.slice(0, 6);
+      console.log('[Scan] checking candidates against RDW:', top);
+      const results = await Promise.all(
+        top.map(c => firstValueFrom(this._rdwService.lookupVehicle(c)))
+      );
+      console.log('[Scan] RDW results:', results.map((v, i) => `${top[i]}:${v ? 'hit' : 'miss'}`));
+      const matchIndex = results.findIndex(v => v?.massa_ledig_voertuig);
+      const matchedPlate = matchIndex >= 0 ? top[matchIndex] : null;
+      console.log('[Scan] matched:', matchedPlate);
 
       this._zone.run(() => {
         this.plateInput = matchedPlate ?? candidates[0];


### PR DESCRIPTION
## Problems fixed

1. **Sequential RDW lookups were slow / appeared frozen**: The previous fix tried candidates one-by-one (up to 6 × 2 HTTP calls = 12 sequential requests). The UI showed "Kenteken herkennen..." the entire time with no feedback, looking like a hang.

2. **No visibility into what was happening**: No console logs between OCR completing and the result appearing.

## Fix

- Replace sequential `for...await` with `Promise.all` — all candidates are checked in parallel, total wait = one round-trip instead of N
- Add `console.log` lines showing which candidates were checked and which matched, so failures are diagnosable in DevTools

## Test flow (to verify)

1. Pull latest, run `ng serve`
2. Triple-tap **NL** badge to enable scan
3. Upload `39-NBT-5.jpg` from gallery
4. Look for these new log lines after `candidates:`:
   ```
   [Scan] checking candidates against RDW: ['39-NB-T5', '39-NBT-5', ...]
   [Scan] RDW results: ['39-NB-T5:miss', '39-NBT-5:hit', ...]
   [Scan] matched: 39-NBT-5
   ```
5. Vehicle info should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)